### PR TITLE
Feat/add test suite

### DIFF
--- a/TestSuite/WrapperClassesTestSuite/BoundedListWrapperTest.cpp
+++ b/TestSuite/WrapperClassesTestSuite/BoundedListWrapperTest.cpp
@@ -109,14 +109,14 @@ Class BoundedListWrapperTest {
         static void testPushOutOfCapacity(const T& first, const Ts&... rest) {
             checkParameterTypesAllSame<T, Ts...>();
 
-            if constexpr (capacity >= sizeof... (Ts))
+            if constexpr (capacity >= sizeof... (Ts) + 1)
                 throw std::runtime_error{"testPushOutOfCapacity(): Capacity should be less than the number of passed-in elements"};
             
             bool errorOccured = false;
 
             try {
-                createListWithElements({first, ...rest});
-                createListWithElementsReversed({first, ...rest});
+                createListWithElements<capacity>({first, rest...});
+                createListWithElementsReversed<capacity>({first, rest...});
             }
             catch (const std::exception& e) {
                 errorOccured = true;
@@ -126,11 +126,11 @@ Class BoundedListWrapperTest {
             Assert::equals(errorOccured, true, "testPushOutOfCapacity(): An error should occur here");
         }
 
-        template <class...Ts, class T>
+        template <int capacity = DEFAULT_CAPACITY, class...Ts, class T>
         static void testCopyConstructor(const T& first, const Ts&... rest) {
             checkParameterTypesAllSame<T, Ts...>();
 
-            BoundedListWrapper<T> list = createListWithElements({first, rest...});
+            BoundedListWrapper<T> list = createListWithElements<capacity>({first, rest...});
 
             BoundedListWrapper<T> list2(list);
             BoundedListWrapper<T> list3{list};
@@ -142,14 +142,14 @@ Class BoundedListWrapperTest {
             assertListEqualsUsingForEach(list4, {first, rest...}, fail_message);
         }
         
-        template <class...Ts, class T>
+        template <int capacity = DEFAULT_CAPACITY, class...Ts, class T>
         static void testMoveConstructor(const T& first, const Ts&... rest) {
             checkParameterTypesAllSame<T, Ts...>();
 
             const string fail_list_not_same_message = "testMoveConstructor(): The moved list isn't the same as the original";
             const string fail_not_empty_message = "testMoveConstructor(): The moved-out list should be empty";
             
-            BoundedListWrapper<T> list = createListWithElements({first, rest...});
+            BoundedListWrapper<T> list = createListWithElements<capacity>({first, rest...});
 
             BoundedListWrapper<T> list2(std::move(list));
             assertListEqualsUsingForEach(list2, {first, rest...}, fail_list_not_same_message);
@@ -262,7 +262,7 @@ int main() {
     BoundedListWrapperTest::testOnePopFront(4.0f, 2.0f, 3.9f);
     BoundedListWrapperTest::testOnePopFront(one, two, three);
 
-    BoundedListWrapperTest::testPushOutOfCapacity<4>(1, 2, 3, 4);
+    BoundedListWrapperTest::testPushOutOfCapacity<3>(1, 2, 3, 4);
     BoundedListWrapperTest::testPushOutOfCapacity<4>(one, two, three, four, one);
     BoundedListWrapperTest::testPushOutOfCapacity<3>(2.4f, 2.0f, 3.0f, 4.0f);
 

--- a/TestSuite/WrapperClassesTestSuite/BoundedListWrapperTest.cpp
+++ b/TestSuite/WrapperClassesTestSuite/BoundedListWrapperTest.cpp
@@ -6,6 +6,7 @@
 
 #include <iostream>
 #include <initializer_list>
+#include <stdexcept>
 
 using std::cout;
 
@@ -22,6 +23,23 @@ Class BoundedListWrapperTest {
         template <class E, class T>
             using MonadCallBackType = E (BoundedListWrapper<T>::*) (const T&);
     public:
+        template <int capacity = DEFAULT_CAPACITY, class T>
+        static void testNegativeCapacity() {
+            if constexpr (capacity >= 0)
+                throw std::runtime_error{"testNegativeCapacity(): Capacity should be negative here"};
+            
+            bool errorOccured = false;
+
+            try {
+                BoundedListWrapper<T> list = createEmptyList<capacity, T>();
+            } catch (const std::exception& error) {
+                std::cout << "testNegativeCapacity() detects \"" << error.what() << "\" thrown" << std::endl;
+                errorOccured = true;
+            }
+
+            Assert::equals(errorOccured, true, "testNegativeCapacity(): An error should occur here");
+        }
+
         template <int capacity = DEFAULT_CAPACITY, class T>
         static void testEmpty() {
             BoundedListWrapper<T> list = createEmptyList<capacity, T>();
@@ -212,7 +230,11 @@ int main() {
     string three = "three";
     string four = "four";
 
-    BoundedListWrapperTest::testEmpty<4, int>();
+    //BoundedListWrapperTest::testNegativeCapacity<-2, int>();
+    //BoundedListWrapperTest::testNegativeCapacity<10, string>();
+    //BoundedListWrapperTest::testNegativeCapacity<-10, string>();
+
+    BoundedListWrapperTest::testEmpty<0, int>();
     BoundedListWrapperTest::testEmpty<4, char>();
     BoundedListWrapperTest::testEmpty<4, string>();
     BoundedListWrapperTest::testEmpty<4, float>();

--- a/TestSuite/WrapperClassesTestSuite/TableWrapperTest.cpp
+++ b/TestSuite/WrapperClassesTestSuite/TableWrapperTest.cpp
@@ -1,0 +1,26 @@
+#include "visual_class_macros.h"
+
+#include "TestSuite/Assert.h"
+
+#include "WrapperClasses/TableWrapper.h"
+
+#include <iostream>
+#include <initializer_list>
+
+using std::cout;
+
+template <class T1, class T2, class... RestTs>
+constexpr bool is_all_same = std::is_same_v<T1, T2> && is_all_same<T2, RestTs...>;;
+
+template <class T1, class T2>
+constexpr bool is_all_same<T1, T2> = std::is_same_v<T1, T2>; 
+
+Class TableWrapperTest {
+    public:
+        
+    private:
+};
+
+int main() {
+
+}

--- a/WrapperClasses/BoundedListWrapper.h
+++ b/WrapperClasses/BoundedListWrapper.h
@@ -10,39 +10,46 @@
 using std::vector;
 
 template<class T>
-Class BoundedListWrapper : public ListWrapper<T>{
+Class BoundedListWrapper : public ListWrapper<T> {
 private:
     const int capacity;
 public:
-    BoundedListWrapper(int capacity = 0) : ListWrapper(), capacity(capacity) {
+    BoundedListWrapper(int capacity = 0) : ListWrapper<T>(), capacity(capacity) {
         
     }
 
-    BoundedListWrapper(const BoundedListWrapper &wrapper) : ListWrapper(wrapper), capacity(wrapper.capacity) {
+    BoundedListWrapper(const BoundedListWrapper &wrapper) : ListWrapper<T>(wrapper), capacity(wrapper.capacity) {
 
     }
 
-    BoundedListWrapper(BoundedListWrapper &&wrapper) noexcept : ListWrapper(std::move(wrapper)), capacity(wrapper.capacity) {
+    BoundedListWrapper(BoundedListWrapper &&wrapper) noexcept : ListWrapper<T>(std::move(wrapper)), capacity(wrapper.capacity) {
         
     }
 
     void pushBack(const T &item) override {
         if (this->getSize() == capacity)
             throw std::length_error("Size of bounded list exceeds capacity");
-        ListWrapper::pushBack(item);
+        ListWrapper<T>::pushBack(item);
     }
 
     void pushFront(const T &item) override {
         if (this->getSize() == capacity)
             throw std::length_error("Size of bounded list exceeds capacity");
-        ListWrapper::pushFront(item);
+        ListWrapper<T>::pushFront(item);
     }
+
+    virtual const T& operator[] (int id) const override {
+        while (this->getSize() <= id) {
+            this->padZeroToBack();
+        }
+        return ListWrapper<T>::operator[](id);
+    };
 
     virtual T& operator[] (int id) override {
         while (this->getSize() <= id) {
-            this->pushBack(0);
+            this->padZeroToBack();
         }
-        return ListWrapper::operator[](id);
+        return ListWrapper<T>::operator[](id);
     }
 };
 

--- a/WrapperClasses/ListWrapper.h
+++ b/WrapperClasses/ListWrapper.h
@@ -10,7 +10,7 @@ using std::vector;
 template<class T>
 Class ListWrapper {
 private:
-    vector<T> list;
+    mutable vector<T> list;
 public:
     virtual void pushBack(const T& item) {
         list.push_back(item);
@@ -84,12 +84,16 @@ public:
         return list.end();
     }
 
-    const T& operator[] (int id) const {
+    virtual const T& operator[] (int id) const {
         return list.at(id);
     }
 
     virtual T& operator[] (int id) {
         return list.at(id);
+    }
+protected:
+    void padZeroToBack() const {
+        list.push_back(0);
     }
 };
 


### PR DESCRIPTION
- Add move and copy constructor test to List & BoundedList Wrapper
- Fix BoundedListWrapper bugs upon running tests includings:
   - Injected Class Name does not work in this context and reference to base class ListWrapper must be made dependent
   - Make the underlying vector of ListWrapper mutable, this shouldn't affect too much because push and pop isn't available in const version and operator[] const exposes const ref anyways
   - Add a protected padZeroToBack method to ListWrapper
   - Make the BoundedListWrapper operator[] call padZeroToBack instead of pushBack(0)
   - Add a virtual const version of operator[] to BoundedListWrapper