### PR TITLE
Fix/wrapper destructors

### DIFF
--- a/WrapperClasses/BoundedListWrapper.h
+++ b/WrapperClasses/BoundedListWrapper.h
@@ -27,6 +27,8 @@ public:
         
     }
 
+    virtual ~BoundedListWrapper() = default;
+
     void pushBack(const T &item) override {
         if (this->getSize() == capacity)
             throw std::length_error("Size of bounded list exceeds capacity");

--- a/WrapperClasses/ListWrapper.h
+++ b/WrapperClasses/ListWrapper.h
@@ -57,6 +57,8 @@ public:
         
     }
 
+    virtual ~ListWrapper() = default;
+
     ListWrapper& operator=(const ListWrapper &wrapper) = delete;
     ListWrapper& operator=(ListWrapper<T> &&wrapper) = delete;
 

--- a/WrapperClasses/TableWrapper.h
+++ b/WrapperClasses/TableWrapper.h
@@ -69,6 +69,8 @@ public:
 
     }
 
+    virtual ~TableWrapper() = default;
+
     TableWrapper& operator=(const TableWrapper &tableWrapper) = delete;
     TableWrapper& operator=(TableWrapper &&tableWrapper) = delete;
 


### PR DESCRIPTION
Add virtual destructors to wrapper classes to avoid undefined behaviors when destruct their derived classes